### PR TITLE
adding const and let to the linter configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ module.exports = {
         'no-shadow': 0,
         'no-unused-vars': 2,
         'no-with': 2,
+        'no-var': 1,
         'vars-on-top': 1,
         'no-inner-declarations': 1,
         'guard-for-in': 1,
@@ -92,4 +93,7 @@ module.exports = {
         'expect': false,
         'spyOn': false
     },
+    'ecmaFeatures': {
+        'blockBindings': true
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-flexshopper",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ESLint FlexShopper configuration",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Now we can use `let` and `const` and when we use `var` we have a `warning`

### Modified files
- index.js
- package.json