### PR TITLE
Feature/prefer const

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = {
         'vars-on-top': 1,
         'no-inner-declarations': 1,
         'guard-for-in': 1,
-        'prefer-const': 2,
+        'prefer-const': 1,
         'object-curly-spacing': [2, 'always'],
         'quotes': [
             2,

--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ module.exports = {
         'vars-on-top': 1,
         'no-inner-declarations': 1,
         'guard-for-in': 1,
+        'prefer-const': 2,
         'object-curly-spacing': [2, 'always'],
         'quotes': [
             2,

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = {
         'vars-on-top': 1,
         'no-inner-declarations': 1,
         'guard-for-in': 1,
-        'prefer-const': 1,
+        'prefer-const': 2,
         'object-curly-spacing': [2, 'always'],
         'quotes': [
             2,


### PR DESCRIPTION
Now, when we declare a `let` and never change the initial value we are going to have warning suggesting use `const` instead