### PR TITLE
Bugfix strict mode duplicated

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = {
         ],
         'strict': [
             2,
-            'never'
+            'function'
         ],
         'new-cap': 2,
         'guard-for-in': 2,

--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ module.exports = {
             2,
             'never'
         ],
-        'strict': 2,
         'new-cap': 2,
         'guard-for-in': 2,
         'no-bitwise': 2,

--- a/index.js
+++ b/index.js
@@ -60,7 +60,6 @@ module.exports = {
         'no-var': 1,
         'vars-on-top': 1,
         'no-inner-declarations': 1,
-        'guard-for-in': 1,
         'prefer-const': 2,
         'object-curly-spacing': [2, 'always'],
         'quotes': [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-flexshopper",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "ESLint FlexShopper configuration",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
We were using the last rule

```
‘strict’: 2
```

In ESLint the Function scope for the strict mode is the default.