### PR TITLE
fixing bug for strict mode

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -7,7 +7,7 @@ module.exports = {
         'no-var': 2,
         'strict': [
             2,
-            'function'
+            'global'
         ],
     },
     'parser': 'babel-eslint',

--- a/es6.js
+++ b/es6.js
@@ -4,7 +4,11 @@ module.exports = {
         'es6': true
     },
     'rules': {
-        'no-var': 2
+        'no-var': 2,
+        'strict': [
+            2,
+            'function'
+        ],
     },
     'parser': 'babel-eslint',
     'ecmaFeatures': {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = {
         ],
         'strict': [
             2,
-            'global'
+            'function'
         ],
         'new-cap': 2,
         'guard-for-in': 2,


### PR DESCRIPTION
Now in `es5` we are using strict mode in `function` and in `es6` in `global`