### PR TITLE
strict mode

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -1,17 +1,18 @@
 module.exports = {
     'extends': 'flexshopper/index.js',
     'env': {
-        'es6': true
+        'es6': true,
+        'node': true,
+        'mongo': true,
+        'mocha': true,
+        'commonjs': true
+    },
+    'parserOption': {
+        'ecmaVersion': 6
     },
     'rules': {
         'no-var': 2,
-        'strict': [
-            2,
-            'safe'
-        ],
-    },
-    'parser': 'babel-eslint',
-    'ecmaFeatures': {
-        'blockBindings': true
+        'strict': [2, 'global'],
+        'keyword-spacing': 2
     }
 };

--- a/es6.js
+++ b/es6.js
@@ -7,7 +7,7 @@ module.exports = {
         'no-var': 2,
         'strict': [
             2,
-            'global'
+            'safe'
         ],
     },
     'parser': 'babel-eslint',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-flexshopper",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "ESLint FlexShopper configuration",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
`babel-parser` is setting the rule `sourceType` equal to `module` because in `es6` you should be using `import and export` aka `modules`.

The `strict mode` is detecting you code as a `module type` instead `script type`